### PR TITLE
Fix copy/paste in Minmatar ships guide: Bantam -> Burst

### DIFF
--- a/content/upgrading-ships/minmatar/index.md
+++ b/content/upgrading-ships/minmatar/index.md
@@ -64,7 +64,7 @@ It has potent bonuses to remote shield booster modules,
 allowing it to "heal" allied ships in battle.
 However, it is not very useful to a solo pilot.
 
-For this reason, we recommend that you do not use the Bantam for now.
+For this reason, we recommend that you do not use the Burst for now.
 
 ##### Vigil
 


### PR DESCRIPTION
Looks like the section on the Burst was copied from the Caldari version.