### PR TITLE
Rename EM Ward Amplifier I → EM Shield Amplifier I

### DIFF
--- a/content/upgrading-ships/caldari/heron.md
+++ b/content/upgrading-ships/caldari/heron.md
@@ -15,7 +15,7 @@
     Data Analyzer I
     Relic Analyzer I
     Medium Shield Extender I
-    EM Ward Amplifier I
+    EM Shield Amplifier I
     1MN Afterburner I
 
     Damage Control I
@@ -48,7 +48,7 @@ This ship mounts a `Medium Shield Extender I` to increase its shield HP.
 The additional HP should rarely be required, as the ship should be avoiding combat,
 but may help deflect some stray shots will you escape.
 
-It also fits a `Damage Control I` and an `EM Ward Amplifier I` to increase its resistance to damage.
+It also fits a `Damage Control I` and an `EM Shield Amplifier I` to increase its resistance to damage.
 
 ### Utility
 


### PR DESCRIPTION
As documented at https://forum.eveuniversity.org/viewtopic.php?t=117865, the "Ward Amplifier" is now named the "Shield Amplifier" and this fit needs updating accordingly